### PR TITLE
added netstandard2.0 support

### DIFF
--- a/Serilog.Sinks.XUnit3/IsExternalInit.cs
+++ b/Serilog.Sinks.XUnit3/IsExternalInit.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal class IsExternalInit { }
+}

--- a/Serilog.Sinks.XUnit3/Serilog.Sinks.XUnit3.csproj
+++ b/Serilog.Sinks.XUnit3/Serilog.Sinks.XUnit3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -30,20 +30,20 @@
         <DocumentationFile>bin\Release\net8.0\Serilog.Sinks.XUnit3.xml</DocumentationFile>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
-      <PackageReference Include="Serilog" Version="4.3.0" />
-      <PackageReference Include="xunit.v3.extensibility.core" Version="3.0.1" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
+		<PackageReference Include="Serilog" Version="4.3.0" />
+		<PackageReference Include="xunit.v3.extensibility.core" Version="3.0.1" />
+	</ItemGroup>
 
-    <PropertyGroup>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    </PropertyGroup>
+	<PropertyGroup>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <None Include="../LICENSE" Pack="true" Visible="false" PackagePath=""/>
-        <None Include="../README.md" Pack="true" Visible="false" PackagePath=""/>
-        <None Include="../icon.png" Pack="true" Visible="false" PackagePath=""/>
-    </ItemGroup>
+	<ItemGroup>
+		<None Include="../LICENSE" Pack="true" Visible="false" PackagePath=""/>
+		<None Include="../README.md" Pack="true" Visible="false" PackagePath=""/>
+		<None Include="../icon.png" Pack="true" Visible="false" PackagePath=""/>
+	</ItemGroup>
 
 </Project>

--- a/Serilog.Sinks.XUnit3/XUnit3TestOutputSink.cs
+++ b/Serilog.Sinks.XUnit3/XUnit3TestOutputSink.cs
@@ -36,8 +36,12 @@ public sealed class XUnit3TestOutputSink(IOptions<XUnit3TestOutputSinkOptions> o
     /// <inheritdoc cref="ILogEventSink.Emit"/>
     public void Emit(LogEvent logEvent)
     {
+#if NET8_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(logEvent);
-
+#else
+        if (logEvent is null)
+            throw new ArgumentNullException(nameof(logEvent));
+#endif
         using var stringWriter = new StringWriter();
         _messageTemplateTextFormatter.Format(logEvent, stringWriter);
         var message = stringWriter.ToString().Trim();


### PR DESCRIPTION
Great that you created this package to replace [the former serilog-sinks-xunit](https://github.com/trbenning/serilog-sinks-xunit) however it was missing Net Standard 2.0 support which sadly lots of .NET projects still rely on, this PR fixes that.

Addresses https://github.com/Stepami/serilog-sinks-xunit-v3/issues/6